### PR TITLE
Update for Rails 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,18 @@ It all starts in the database. **Foreign keys** are columns that refer to the pr
 
 Like any other column, foreign keys are accessible through instance methods of the same name. For example, a migration that looks like this:
 
-
-
 ```ruby
-class AddAuthorIdToPosts < ActiveRecord::Migration
+class AddAuthorIdToPosts < ActiveRecord::Migration[7.1]
   def change
     change_table :posts do |t|
-      t.integer :author_id
+      t.references :author, foreign_key: true
     end
   end
 end
 ```
+Remember, Active Record uses its [Inflector](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html) to switch between the singular and plural forms of your models.
+
+You can see the entire [list of class methods](https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html) in the Rails API docs.
 
 Would mean you could find a post's author with the following Active Record query:
 
@@ -99,7 +100,7 @@ Now we can look up an author's posts just as easily:
 @author.posts #=> [#<Post id=3>, #<Post id=8>]
 ```
 
-Remember, Active Record uses its [Inflector][api_inflector] to switch between the singular and plural forms of your models.
+Remember, Active Record uses its [Inflector](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html) to switch between the singular and plural forms of your models.
 
 <table border="1" cellpadding="4" cellspacing="0">
   <tr>
@@ -162,7 +163,7 @@ new_author = @post.build_author(name: "Leeroy Jenkins")
 
 Remember, if you used the `build_` option, you'll need to persist your new `author` with `#save`.
 
-These methods are also documented in the [Rails Associations Guide][guides_associations].
+These methods are also documented in the [Rails Associations Guide](https://guides.rubyonrails.org/association_basics.html).
 
 ### Collection Convenience
 
@@ -285,9 +286,4 @@ One-to-one and many-to-one relationships only require a single foreign key, whic
 Many-to-many relationships require a join table containing a foreign key for both models. The models are joined using `has_many :through` statements.
 
 
-You can see the entire [list of class methods][api_associations_class_methods] in the Rails API docs.
-
-[guides_associations]: http://guides.rubyonrails.org/association_basics.html
-[guides_has_many_through]: http://guides.rubyonrails.org/association_basics.html#the-has-many-through-association
-[api_associations_class_methods]: http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html
-[api_inflector]: http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html
+You can see the entire [list of class methods](https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html) in the Rails API docs.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ It all starts in the database. **Foreign keys** are columns that refer to the pr
 
 Like any other column, foreign keys are accessible through instance methods of the same name. For example, a migration that looks like this:
 
+
+
 ```ruby
 class AddAuthorIdToPosts < ActiveRecord::Migration
   def change
@@ -150,7 +152,7 @@ This will return a new `Post` object with the `author_id` already set for you! W
 The setup process is a little bit less intuitive for singular associations. Remember, a post `belongs_to` an author. The verbose way of creating this association would be like so:
 
 ```ruby
-@post.author = Author.new(name: "Leeroy Jenkins") 
+@post.author = Author.new(name: "Leeroy Jenkins")
 ```
 In the previous section, `@author.posts` always exists, even if it's an empty array. Here, `@post.author` is `nil` until the author is defined, so Active Record can't give us something like `@post.author.build`. Instead, it prepends the attribute with `build_` or `create_`. The `create_` option will persist to the database for you.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Like any other column, foreign keys are accessible through instance methods of t
 class AddAuthorIdToPosts < ActiveRecord::Migration[7.1]
   def change
     change_table :posts do |t|
-      t.references :author, foreign_key: true
+      t.references :author
     end
   end
 end


### PR DESCRIPTION
This pull request updates the `README.md` to modernize Rails documentation references and clarify association examples. The most important changes include updating code samples to use current Rails migration syntax and replacing outdated or indirect links with direct, up-to-date URLs from the official Rails documentation.

**Documentation improvements:**

* Updated migration example to use `ActiveRecord::Migration[7.1]` and `t.references` with `foreign_key: true` for defining foreign keys, reflecting current Rails best practices.
* Replaced indirect or old-style reference links with direct links to the latest Rails API and Guides, ensuring readers are directed to the most accurate resources:
  - Updated Inflector and Associations ClassMethods links to their canonical Rails API URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R103) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L286-R289)
  - Updated Rails Associations Guide link to the current guides URL.
* Removed obsolete footnote-style reference definitions at the end of the file, consolidating all documentation links inline.